### PR TITLE
Added 2 new behaviours

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,18 @@ http://www.codeproject.com/Articles/18954/Interop-Forms-Toolkit-Tutorial
 https://www.microsoft.com/en-us/download/details.aspx?id=3264
 
 https://interoptoolkitcs.codeplex.com (also imported to https://github.com/froque/interoptoolkitcs)
+
+### Info
+At present state this tool does not override files previously generated. 
+When forms with unsupported parameter types are found, the initialize method will be generated with a paramenter with the root type "Object".
+
+### How to Debug 
+
+Open project properties 
+- Start Action 
+	- choose "Start external program"
+	- and write path to visual studio. (Ex: "C:\Program Files (x86)\Microsoft Visual Studio 14.0\Common7\IDE\devenv.exe")
+- On Command line arguments "/rootsuffix Exp"
+- Start application
+- Create project in newly opened VS window
+- Run tool

--- a/VSIXInteropFormsToolkit/Resource.Designer.cs
+++ b/VSIXInteropFormsToolkit/Resource.Designer.cs
@@ -169,6 +169,15 @@ namespace VSIXInteropFormsToolkit {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Parameters with unsupported types found for initialize method, type Object will be used instead..
+        /// </summary>
+        internal static string InitMethodWarningMsg {
+            get {
+                return ResourceManager.GetString("InitMethodWarningMsg", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to InteropForm Wrapper Classes.
         /// </summary>
         internal static string INTEROP_FORM_PROXY_FOLDER_NAME {

--- a/VSIXInteropFormsToolkit/Resource.resx
+++ b/VSIXInteropFormsToolkit/Resource.resx
@@ -174,4 +174,7 @@
   <data name="PropertyErrMsg" xml:space="preserve">
     <value>Type {0} is not supported. Property {1} will not be generated.</value>
   </data>
+  <data name="InitMethodWarningMsg" xml:space="preserve">
+    <value>Parameters with unsupported types found for initialize method, type Object will be used instead.</value>
+  </data>
 </root>


### PR DESCRIPTION
- If a previously generated file exists, tool ignores new generation
- If a form with unsupported parameter types found, creates them with type Object in the initialize method