### PR TITLE
Edit vsixmanifest to support Visual Studio 2019 (16.0)

### DIFF
--- a/VSIXInteropFormsToolkit/source.extension.vsixmanifest
+++ b/VSIXInteropFormsToolkit/source.extension.vsixmanifest
@@ -7,7 +7,7 @@
     </Metadata>
     <Installation>
         <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[14.0]" />
-        <InstallationTarget Version="[15.0,16.0)" Id="Microsoft.VisualStudio.Community" />
+        <InstallationTarget Version="[15.0,17.0)" Id="Microsoft.VisualStudio.Community" />
     </Installation>
     <Dependencies>
         <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
@@ -17,6 +17,6 @@
         <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
     </Assets>
     <Prerequisites>
-        <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,16.0)" DisplayName="Visual Studio core editor" />
+        <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,17.0)" DisplayName="Visual Studio core editor" />
     </Prerequisites>
 </PackageManifest>


### PR DESCRIPTION
A square bracket means the value is included.
A parenthesis would mean that the value is excluded,
so you can also set [11.0,16.0). You can also target a
minor version (like 15.3) using the build number
(such as 15.0.26208.1).
https://msdn.microsoft.com/en-us/magazine/mt493251.aspx